### PR TITLE
Rename using_bind_vars to bind for succintness

### DIFF
--- a/src/main/scala/edu/chop/cbmi/dataExpress/dsl/statements/Copy.scala
+++ b/src/main/scala/edu/chop/cbmi/dataExpress/dsl/statements/Copy.scala
@@ -112,9 +112,14 @@ class CopyFromQueryPre(query : String) extends CopyPre{
 
   def from(source : Store) = new CopyFromQuery(query, source, _bind_vars)
 
-  def using_bind_vars(bind_var : Any*) = {
+  def bind(bind_var : Any*) = {
     _bind_vars = bind_var.toSeq map {Some(_)}
     this
+  }
+
+  @deprecated("renamed to `bind`", "0.9.1")
+  def using_bind_vars(bind_var : Any*) = {
+    this.bind(bind_var : _*)
   }
 }
 

--- a/src/main/scala/edu/chop/cbmi/dataExpress/dsl/statements/Get.scala
+++ b/src/main/scala/edu/chop/cbmi/dataExpress/dsl/statements/Get.scala
@@ -46,9 +46,14 @@ class GetFromQuery(query : String) extends GetFrom{
     case _ => throw UnsupportedStoreType(source, "GetFromQuery.from")
   }
 
-  def using_bind_vars(bind_var : Any*) = {
+  def bind(bind_var : Any*) = {
     _bind_vars = bind_var.toSeq map {Some(_)}
     this
+  }
+
+  @deprecated("renamed to `bind`", "0.9.1")
+  def using_bind_vars(bind_var : Any*) = {
+    this.bind(bind_var : _*)
   }
 }
 

--- a/src/test/scala/edu/chop/cbmi/dataExpress/test/dsl/CopySpec.scala
+++ b/src/test/scala/edu/chop/cbmi/dataExpress/test/dsl/CopySpec.scala
@@ -136,7 +136,7 @@ class CopySpec extends PresidentsSpecWithSourceTarget {
 
           val bindable_statement = """select * from %s.%s where %s= ?""".format(schema.get, PRESIDENTS,
             source_backend.sqlDialect.quoteIdentifier("num_terms"))
-          commit_on_success(target_db) {copy query bindable_statement using_bind_vars 2 from source_db to target_db create TTP_THREE}
+          commit_on_success(target_db) {copy query bindable_statement bind 2 from source_db to target_db create TTP_THREE}
           BackendOps.add_table_name(target_backend, TTP_THREE, schema)
           add_compare_table_assertion(TTP_THREE, ttp_map)
 

--- a/src/test/scala/edu/chop/cbmi/dataExpress/test/dsl/GetFeatureSpec.scala
+++ b/src/test/scala/edu/chop/cbmi/dataExpress/test/dsl/GetFeatureSpec.scala
@@ -37,11 +37,11 @@ class GetFeatureSpec extends PresidentsFeatureSpecWithSourceTarget{
 
     scenario("get is invoked with a bindable query statement"){
       register store SqlDb(prop_file_source, schema) as source
-      val table = get query bindable_statement using_bind_vars 1 from source
+      val table = get query bindable_statement bind 1 from source
       (0 /: table){ (i,r) => i+1} should equal(default_otp_count)
       table foreach { row => row.num_terms.asu[Int] should equal(1)}
 
-      val table2 = get query bindable_statement using_bind_vars 2 from source
+      val table2 = get query bindable_statement bind 2 from source
       (0 /: table2){ (i,r) => i+1} should equal(default_ttp_count)
       table2 foreach { row => row.num_terms.asu[Int] should equal(2)}
       ETL.cleanup()


### PR DESCRIPTION
A deprecation warning has been added to using_bind_vars to maintain compatibility until it is decided to be removed.
